### PR TITLE
Adding the possibility to configure the max scanned wifis

### DIFF
--- a/src/WifiLocation.cpp
+++ b/src/WifiLocation.cpp
@@ -52,6 +52,10 @@ String WifiLocation::getSurroundingWiFiJson() {
     String wifiArray = "[\n";
 
     int8_t numWifi = WiFi.scanNetworks();
+    if(numWifi > MAX_WIFI_SCAN) {
+        numWifi = MAX_WIFI_SCAN;
+    }
+
 #ifdef DEBUG_WIFI_LOCATION
     Serial.println(String(numWifi) + " WiFi networks found");
 #endif // DEBUG_WIFI_LOCATION

--- a/src/WifiLocation.h
+++ b/src/WifiLocation.h
@@ -20,9 +20,10 @@
 #include <WiFiClientSecure.h>
 #else
 #error Wrong platform
-#endif 
+#endif
 
 #define MAX_CONNECTION_TIMEOUT 5000
+#define MAX_WIFI_SCAN 127
 
 typedef struct {
     float lat = 0;
@@ -50,4 +51,3 @@ protected:
 };
 
 #endif
-


### PR DESCRIPTION
This pull request adds a macro to limit the number of scanned Wifis to send to Google's API.

I was using the ESP8266 to get location from my surrounds Wifis and it worked like a charm in my house, but it didn't work at my friend's apartment (ESP keeps crashing or returned lat=0.0000000, lon=0.0000000). It turns out that if there is a lot of Wifis in the region, the ESP can't handle the big message due to memory issues. So I changed the maximum scanned Wifis to 8 and it worked flawlessly at my friend's apartment.